### PR TITLE
[ALFHOST-899] Do not read manifest info again after they are set

### DIFF
--- a/alfresco-actuators/src/main/java/eu/xenit/actuators/services/ManifestInfo.java
+++ b/alfresco-actuators/src/main/java/eu/xenit/actuators/services/ManifestInfo.java
@@ -38,6 +38,7 @@ public class ManifestInfo {
     public void setManifestProperties(final ServletContext servletContext) {
         if (manifestProperties != null && !manifestProperties.isEmpty()) {
             logger.debug("MANIFEST properties already loaded");
+            return;
         }
 
         final String name = "/META-INF/MANIFEST.MF";


### PR DESCRIPTION
This method is implicated in a high CPU load event, probably because it is being called all the time in the healthcheck endpoint.

Since this manifest file does not change while the application is running, it is not necessary to re-read and re-parse the file every time, instead using a cached version.